### PR TITLE
update Vundle repo and calling convention

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,6 @@
 [submodule "tmux"]
 	path = tmux
 	url = https://github.com/ceocoder/tmuxrc.git
-[submodule "vim/bundle/vundle"]
-	path = vim/bundle/vundle
-	url = https://github.com/gmarik/vundle.git
+[submodule "vim/bundle/Vundle.vim"]
+	path = vim/bundle/Vundle.vim
+	url = https://github.com/VundleVim/Vundle.vim.git

--- a/vimrc
+++ b/vimrc
@@ -2,12 +2,12 @@ set encoding=utf-8
 set nocompatible               " be iMproved
 filetype off                   " required!
 
-set rtp+=~/.vim/bundle/vundle/
-call vundle#rc()
-let g:vundle_lazy_load=1
+set rtp+=~/.vim/bundle/Vundle.vim
+call vundle#begin()
+" let g:vundle_lazy_load=1
 
 " let Vundle manage Vundle
-Plugin 'gmarik/vundle'
+Plugin 'VundleVim/Vundle.vim'
 
 " Git
 Plugin 'tpope/vim-fugitive'


### PR DESCRIPTION
update Vundle repo from `gmarik/vundle` to `VundleVim/Vundle.vim`

https://github.com/VundleVim/Vundle.vim/blob/master/autoload/vundle.vim => 

``` vim
" Alternative to vundle#rc, offers speed up by modifying rtp only when end()
" called later.
func! vundle#begin(...) abort
  let g:vundle#lazy_load = 1
  call call('vundle#rc', a:000)
endf
```
